### PR TITLE
changed failure message in contact page

### DIFF
--- a/src/Contact.jsx
+++ b/src/Contact.jsx
@@ -24,7 +24,7 @@ function Contact() {
         setState({ name: '', email: '', subject: '', message: '' });
       })
       .catch(() => {
-        setResult({success: false, message: 'Something went wrong. Please try again later'});
+        setResult({success: false, message: 'Something went wrong. Please use LinkedIn icon below to ensure contact'});
       });
   }
 


### PR DESCRIPTION
Updated the contact page failure response message to prompt individuals to use the working LinkedIn icon if e-mail fails to send. 